### PR TITLE
Remove deprecated projects from Transifex config

### DIFF
--- a/legacy/.tx/config
+++ b/legacy/.tx/config
@@ -2,12 +2,6 @@
 host = https://www.transifex.com
 lang_map = zh_CN: zh-cn, zh_TW: zh-tw, pt_BR: pt-br, es_419: es-419
 
-[scratch-legacy.tips]
-file_filter = documentation/<lang>/LC_MESSAGES/django.po
-source_file = documentation/django.pot
-source_lang = en
-type = PO
-
 [scratch-legacy.web]
 file_filter = ui/<lang>/LC_MESSAGES/django.po
 source_file = ui/django.pot
@@ -17,11 +11,5 @@ type = PO
 [scratch-legacy.web-js]
 file_filter = ui/<lang>/LC_MESSAGES/djangojs.po
 source_file = ui/djangojs.pot
-source_lang = en
-type = PO
-
-[scratch-legacy.editor-full]
-file_filter = editor/static/locale/<lang>.po
-source_file = fullEditor.pot
 source_lang = en
 type = PO


### PR DESCRIPTION
As we've migrated from scratchr2 -> scratch-www we've used up our quota of strings. In an effort to reclaim space, we removed projects from Transifex. This syncs the repo with what we have set up in Transifex.